### PR TITLE
fix deploy command

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,5 +27,5 @@ jobs:
         run: |
           eval "$(ssh-agent -s)"
           ssh-add ~/.ssh/my-ssh-key
-          ssh -o "StrictHostKeyChecking=no" -p ${SSH_PORT} ${SSH_USERNAME}@${SSH_HOST}  -i ~/.ssh/my-ssh-key 'bash -s' < deploy.sh https://${SSH_USERNAME}:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}
+          ssh -o "StrictHostKeyChecking=no" -p ${SSH_PORT} ${SSH_USERNAME}@${SSH_HOST}  -i ~/.ssh/my-ssh-key 'bash -s' < deploy.sh https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-cd `dirname $0`
-
 # 第一引数はgitリポジトリを指定(以下例)
 # sh deploy.sh https://github.com/dockersamples/example-voting-app
 


### PR DESCRIPTION
## やったこと
- githubactionsからgit cloneする際のコマンド変更

## エラー内容
```
...
remote: Invalid username or password.
fatal: Authentication failed for 'https://github.com/CA21engineer/HouseHackathonUnityServer/'
...
```

## 参考
https://qiita.com/broken55/items/fd2f65474243560b71eb