### PR TITLE
親の接続切れ時に全コネクションを閉じる処理追加

### DIFF
--- a/apiServer/src/main/scala/com/github/CA21engineer/HouseHackathonUnityServer/service/RoomActorRef.scala
+++ b/apiServer/src/main/scala/com/github/CA21engineer/HouseHackathonUnityServer/service/RoomActorRef.scala
@@ -10,15 +10,15 @@ case class RoomActorRef[Coordinate, Operation](playingDataSharingActorRef: (Acto
 object RoomActorRef {
 
   // TODO
-  def create[Coordinate, Operation](implicit materializer: Materializer): RoomActorRef[Coordinate, Operation] = {
+  def create[Coordinate, Operation](killSwitch: SharedKillSwitch)(implicit materializer: Materializer): RoomActorRef[Coordinate, Operation] = {
     RoomActorRef[Coordinate, Operation](
-      playingDataSharingActorRef = createSource,
-      operationSharingActorRef = createSource
+      playingDataSharingActorRef = createSource(killSwitch),
+      operationSharingActorRef = createSource(killSwitch)
     )
   }
 
-  def createSource[T](implicit materializer: Materializer): (ActorRef, Source[T, NotUsed]) = {
-    val actorRefSource: Source[T, ActorRef] = Source.actorRef[T](bufferSize = 1000, OverflowStrategy.fail)
+  def createSource[T](killSwitch: SharedKillSwitch)(implicit materializer: Materializer): (ActorRef, Source[T, NotUsed]) = {
+    val actorRefSource: Source[T, ActorRef] = Source.actorRef[T](bufferSize = 1000, OverflowStrategy.fail) via killSwitch.flow
     actorRefSource.toMat(BroadcastHub.sink[T](bufferSize = 256))(Keep.both).run()
   }
 

--- a/apiServer/src/main/scala/com/github/CA21engineer/HouseHackathonUnityServer/service/RoomAggregate.scala
+++ b/apiServer/src/main/scala/com/github/CA21engineer/HouseHackathonUnityServer/service/RoomAggregate.scala
@@ -2,12 +2,12 @@ package com.github.CA21engineer.HouseHackathonUnityServer.service
 
 import akka.NotUsed
 import akka.actor.ActorRef
-import akka.stream.{Materializer, OverflowStrategy}
+import akka.stream.{KillSwitches, Materializer, OverflowStrategy, SharedKillSwitch}
 import akka.stream.scaladsl.{BroadcastHub, Keep, Source}
 
 import scala.util.Try
 
-case class RoomAggregate[T, Coordinate, Operation](parent: (String, ActorRef), children: Set[(String, ActorRef)], roomRef: RoomActorRef[Coordinate, Operation], roomKey: Option[String]) {
+case class RoomAggregate[T, Coordinate, Operation](parent: (String, ActorRef), children: Set[(String, ActorRef)], roomRef: RoomActorRef[Coordinate, Operation], roomKey: Option[String], killSwitch: SharedKillSwitch) {
   // 親を除いた定員
   private val maxCapacity = 3
 
@@ -41,15 +41,16 @@ case class RoomAggregate[T, Coordinate, Operation](parent: (String, ActorRef), c
 
     val (actorRef, source) = RoomAggregate.createActorRef
     val newChildren = (accountId, actorRef)
-    (copy(children = this.children + newChildren), source)
+    (copy(children = this.children + newChildren), source via killSwitch.flow)
   }
 
 }
 
 object RoomAggregate {
-  def create[T, Coordinate, Operation](authorAccountId: String, roomKey: Option[String])(implicit materializer: Materializer): (RoomAggregate[T, Coordinate, Operation], Source[T, NotUsed]) = {
+  def create[T, Coordinate, Operation](authorAccountId: String, roomKey: Option[String], roomId: String)(implicit materializer: Materializer): (RoomAggregate[T, Coordinate, Operation], Source[T, NotUsed]) = {
     val (actorRef, source) = createActorRef
-    (RoomAggregate((authorAccountId, actorRef), Set.empty, RoomActorRef.create, roomKey) ,source)
+    val killSwitch = KillSwitches.shared(roomId)
+    (RoomAggregate((authorAccountId, actorRef), Set.empty, RoomActorRef.create(killSwitch), roomKey, killSwitch) ,source via killSwitch.flow)
   }
 
   def createActorRef[T](implicit materializer: Materializer): (ActorRef, Source[T, NotUsed]) = {

--- a/apiServer/src/main/scala/com/github/CA21engineer/HouseHackathonUnityServer/service/RoomAggregates.scala
+++ b/apiServer/src/main/scala/com/github/CA21engineer/HouseHackathonUnityServer/service/RoomAggregates.scala
@@ -1,9 +1,8 @@
 package com.github.CA21engineer.HouseHackathonUnityServer.service
 
 import akka.NotUsed
-import akka.actor.Status
 import akka.stream.Materializer
-import akka.stream.scaladsl.{Sink, Source}
+import akka.stream.scaladsl.Source
 
 import scala.util.{Failure, Success, Try}
 import com.github.CA21engineer.HouseHackathonUnityServer.repository
@@ -97,7 +96,7 @@ class RoomAggregates[T, Coordinate, Operation](implicit materializer: Materializ
         allMemberHasDirection
           .foreach { a =>
           println(s"Ready通知: ${a._1._1}")
-          a._1._2 ! readyResponse(a._2)
+          a._1._3 ! readyResponse(a._2)
         }
         repository.RoomRepository.create(roomId) // insert db
       }

--- a/apiServer/src/main/scala/com/github/CA21engineer/HouseHackathonUnityServer/service/RoomAggregates.scala
+++ b/apiServer/src/main/scala/com/github/CA21engineer/HouseHackathonUnityServer/service/RoomAggregates.scala
@@ -10,6 +10,19 @@ import scala.util.{Failure, Success, Try}
 class RoomAggregates[T, Coordinate, Operation](implicit materializer: Materializer) {
   val rooms: scala.collection.mutable.Map[String, RoomAggregate[T, Coordinate, Operation]] = scala.collection.mutable.Map.empty
 
+  def watchSource[S](source: Source[S, NotUsed], roomId: String): Source[S, NotUsed] = {
+    source.watchTermination()((f, d) => {
+      d.foreach(_ => closeRoom(roomId))(materializer.executionContext)
+      f
+    })
+  }
+
+  def closeRoom(roomId: String): Unit = {
+    rooms.get(roomId)
+      .flatMap(_ => rooms.remove(roomId))
+      .foreach(_.killSwitch.shutdown())
+  }
+
   def generateRoomId(): String =
     java.util.UUID.randomUUID.toString.replaceAll("-", "")
 
@@ -22,10 +35,10 @@ class RoomAggregates[T, Coordinate, Operation](implicit materializer: Materializ
    *  @return
    */
   def createRoom(authorAccountId: String, roomKey: Option[String]): Source[T, NotUsed] = {
-    val (roomAggregate, source) = RoomAggregate.create[T, Coordinate, Operation](authorAccountId, roomKey)
     val roomId = generateRoomId()
+    val (roomAggregate, source) = RoomAggregate.create[T, Coordinate, Operation](authorAccountId, roomKey, roomId)
     rooms(roomId) = roomAggregate
-    source// via KillSwitches.shared(roomId).flow
+    watchSource(source, roomId)
   }
 
   def searchVacantRoom(roomKey: Option[String]): Try[(String, RoomAggregate[T, Coordinate, Operation])] = {
@@ -36,7 +49,23 @@ class RoomAggregates[T, Coordinate, Operation](implicit materializer: Materializ
   def getRoomAggregate(roomId: String, accountId: String): Option[RoomAggregate[T, Coordinate, Operation]] = {
     this.rooms
       .get(roomId)
-      .filter(a => a.parent._1 == accountId || a.children.exists(_._1 == accountId))
+      .collect {
+        case roomAggregate if roomAggregate.parent._1 == accountId =>
+          roomAggregate.copy(
+            roomRef = roomAggregate.roomRef.copy(
+              playingDataSharingActorRef = (
+                roomAggregate.roomRef.playingDataSharingActorRef._1,
+                watchSource(roomAggregate.roomRef.playingDataSharingActorRef._2, roomId)
+              ),
+              operationSharingActorRef = (
+                roomAggregate.roomRef.operationSharingActorRef._1,
+                watchSource(roomAggregate.roomRef.operationSharingActorRef._2, roomId)
+              )
+            )
+          )
+        case roomAggregate if roomAggregate.children.exists(_._1 == accountId) =>
+          roomAggregate
+      }
   }
 
   def joinRoom(accountId: String, roomKey: Option[String]): Try[Source[T, NotUsed]] =
@@ -66,11 +95,10 @@ class RoomAggregates[T, Coordinate, Operation](implicit materializer: Materializ
           .zip(directions)
           .foreach { a =>
             println(s"Ready通知: ${a._1._1}")
-            Source(List(readyResponse(a._2))) to Sink.actorRef(a._1._2, Status.Success) run()
+            a._1._2 ! readyResponse(a._2)
           }
       }
       this.rooms.update(roomId, newRoomAggregate)
-      //TODO 参加完了通知: 後何人
       allMember.foreach { a =>
         a._2 ! RoomResponse(RoomResponse.Response.JoinRoomResponse(JoinRoomResponse(
           roomId = roomId,

--- a/apiServer/src/main/scala/com/github/CA21engineer/HouseHackathonUnityServer/service/RoomServicePowerApiImpl.scala
+++ b/apiServer/src/main/scala/com/github/CA21engineer/HouseHackathonUnityServer/service/RoomServicePowerApiImpl.scala
@@ -65,6 +65,7 @@ class RoomServicePowerApiImpl(implicit materializer: Materializer) extends RoomS
 
   override def sendResult(in: SendResultRequest, metadata: Metadata): Future[Empty] = {
     CoordinateRepository.recordData(in.roomId, in.ghostRecord)
+    roomAggregates.closeRoom(in.roomId)
     Future.successful(Empty())
   }
 }

--- a/apiServer/src/main/scala/com/github/CA21engineer/HouseHackathonUnityServer/service/RoomServicePowerApiImpl.scala
+++ b/apiServer/src/main/scala/com/github/CA21engineer/HouseHackathonUnityServer/service/RoomServicePowerApiImpl.scala
@@ -64,8 +64,14 @@ class RoomServicePowerApiImpl(implicit materializer: Materializer) extends RoomS
   }
 
   override def sendResult(in: SendResultRequest, metadata: Metadata): Future[Empty] = {
-    CoordinateRepository.recordData(in.roomId, in.ghostRecord)
-    roomAggregates.closeRoom(in.roomId)
-    Future.successful(Empty())
+    // 親のみ書き込み可能
+    roomAggregates
+      .getRoomAggregate(in.roomId, in.accountId)
+      .filter(_.parent._1 == in.accountId)
+      .map { _ =>
+        CoordinateRepository.recordData(in.roomId, in.ghostRecord)
+        roomAggregates.closeRoom(in.roomId)
+      }
+      .fold(Future.failed[Empty](new Exception("Internal Error!!!")))(_ => Future.successful(Empty()))
   }
 }


### PR DESCRIPTION
## やったこと
親の接続が切れた際にその部屋に関係する全コネクションを閉じる

## 詳細仕様
- CreateRoom
- JoinRoom
この二つについては開いた後ゲーム終了までずっと開いている。

**閉じられた際に起きていること**
1. ゲーム終了(ゲームクリア後に親が結果を送信したとき)
2. 親が部屋を解散した(Readyが送られる前)
3. 親の接続が切れた(Readyが送られる後)
4. その他不明なエラー

- CoordinateSharing
親のコネクションが切れると全員のコネクションが切れる

- ChildOperation
子が切れても他に影響はない

- ParentOperation
親のコネクションが切れると全員のコネクションが切れる
