### PR TITLE
リザルト処理&エラー処理の変更

### DIFF
--- a/apiServer/src/main/protobuf/room.proto
+++ b/apiServer/src/main/protobuf/room.proto
@@ -91,7 +91,7 @@ service RoomService {
 
     rpc CoordinateSharing(stream Coordinate) returns (stream Coordinate) {};
 
-    rpc ChildOperation(stream Operation) returns (Empty) {};
+    rpc ChildOperation(stream Operation) returns (stream Empty) {};
     rpc ParentOperation(ParentOperationRequest) returns (stream Operation) {};
 
     rpc SendResult(SendResultRequest) returns (Empty) {};

--- a/apiServer/src/main/protobuf/room.proto
+++ b/apiServer/src/main/protobuf/room.proto
@@ -10,19 +10,23 @@ package room;
 
 message RoomResponse {
     oneof response {
-        CreateRoomResponse createRoomResponse = 1;
-        JoinRoomResponse joinRoomResponse = 2;
-        ReadyResponse readyResponse = 3;
+        JoinRoomResponse joinRoomResponse = 1;
+        ReadyResponse readyResponse = 2;
+        SimpleGameResult result = 3;
+        ErrorType error = 4;
     }
+}
+
+enum ErrorType {
+    UNKNOWN_MESSAGE_TYPE = 0;
+    LOST_CONNECTION_ERROR = 1; // 親or子の接続切れ
+    ROOM_NOT_FOUND_ERROR = 2; // ルームが見つからない, Privateな部屋で合言葉間違いもこれ
 }
 
 message CreateRoomRequest {
     string AccountId = 1;
     string roomKey = 2; // Optional
     string AccountName = 3;
-}
-message CreateRoomResponse {
-    string RoomId = 1;
 }
 
 message JoinRoomRequest {
@@ -80,6 +84,13 @@ message SendResultRequest {
     string RoomId = 1;
     string AccountId = 2;
     repeated Coordinate ghostRecord = 3;
+    bool isGameClear = 4; // ゲームクリアならtrue、ゲームオーバーならfalse
+    int64 date = 5; // 終了時点でのゲームスタートからの経過時間
+}
+
+message SimpleGameResult {
+    bool isGameClear = 1; // ゲームクリアならtrue、ゲームオーバーならfalse
+    int64 date = 2; // 終了時点でのゲームスタートからの経過時間
 }
 
 message Empty {}

--- a/apiServer/src/main/scala/com/github/CA21engineer/HouseHackathonUnityServer/service/RoomServicePowerApiImpl.scala
+++ b/apiServer/src/main/scala/com/github/CA21engineer/HouseHackathonUnityServer/service/RoomServicePowerApiImpl.scala
@@ -37,7 +37,7 @@ class RoomServicePowerApiImpl(implicit materializer: Materializer) extends RoomS
           .map(_.roomRef.playingDataSharingActorRef)
           .map { ref =>
             in.runForeach(a => {
-              println(s"----- playingData: $a")
+//              println(s"----- playingData: $a")
               ref._1 ! a
             })
             ref._2
@@ -60,7 +60,10 @@ class RoomServicePowerApiImpl(implicit materializer: Materializer) extends RoomS
           .getRoomAggregate(roomId, accountId)
           .map(_.roomRef.operationSharingActorRef._1)
           .map { ref =>
-            in.runForeach(a => ref ! a)
+            in.runForeach(a => {
+              println(s"----- childOperation: $a")
+              ref ! a
+            })
             Future.successful(Empty())
           }
           .getOrElse({

--- a/apiServer/src/main/scala/com/github/CA21engineer/HouseHackathonUnityServer/service/RoomServicePowerApiImpl.scala
+++ b/apiServer/src/main/scala/com/github/CA21engineer/HouseHackathonUnityServer/service/RoomServicePowerApiImpl.scala
@@ -93,9 +93,9 @@ class RoomServicePowerApiImpl(implicit materializer: Materializer) extends RoomS
     roomAggregates
       .getRoomAggregate(in.roomId, in.accountId)
       .filter(_.parent._1 == in.accountId)
-      .map { _ =>
+      .map { aggregate =>
         CoordinateRepository.recordData(in.roomId, in.ghostRecord)
-        roomAggregates.closeRoom(in.roomId)
+        aggregate.children.foreach(_._3 ! SimpleGameResult(in.isGameClear, in.date))
       }
       .fold({
         println("sendResult not found")

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,8 @@ services:
     build: apiServer/target/docker/stage
     ports:
       - 18080:18080
+    logging:
+      driver: gcplogs
     environment:
       - MYSQL_HOST=mysql
       - MYSQL_PORT=3306


### PR DESCRIPTION
## 変更点
1. ゲーム終了時に親から受け取ったリザルトを、子に送信
`JoinRoom`のコネクションを利用

2. ゲーム開始以前に子が抜けた場合は`JoinRoomResponse`の更新を全員に送る
`CreateRoom`と`JoinRoom`のコネクションを利用

3. ゲーム開始後に子が抜けた場合は全員に`ErrorType=LOST_CONNECTION_ERROR`を送信
`CreateRoom`と`JoinRoom`のコネクションを利用

4. 部屋が見つからない、合言葉が違う場合は`ErrorType=ROOM_NOT_FOUND_ERROR`を送信
`CreateRoom`と`JoinRoom`のコネクションを利用

5. 基本的にサーバー側でコネクションを閉じることはなく、エラーの際は`ErrorType`を送る
`CreateRoom`と`JoinRoom`のコネクションを利用